### PR TITLE
Make competition dates configurable

### DIFF
--- a/annotation_tool/backend/config.py
+++ b/annotation_tool/backend/config.py
@@ -1,3 +1,6 @@
+import datetime
+from typing import Optional
+
 import streamlit as st
 
 
@@ -25,3 +28,11 @@ def _get_limit(key: str, default_limit):
         return music_config.get(key, default_limit)
     else:
         return default_limit
+
+
+def get_competition_date(key: str) -> Optional[datetime.date]:
+    if competition_config := st.secrets.get("competition"):
+        date_str = competition_config.get(key)
+        if date_str:
+            return datetime.datetime.strptime(date_str, "%Y/%m/%d")
+    return None

--- a/annotation_tool/backend/models.py
+++ b/annotation_tool/backend/models.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional, List, Union, Tuple
 
 import streamlit as st
@@ -164,10 +164,13 @@ def get_user_annotation_count(user_id: str) -> int:
     return user.get_annotation_count()
 
 
-def get_leaderboard_counts():
+def get_leaderboard_counts(
+    start_date: Union[date, datetime, None] = datetime.min, end_date: Union[date, datetime, None] = datetime.max
+):
     annotation_counts = (
         select(Annotation.user_id, User.nickname, func.count(Annotation.id))
         .join(User)
+        .filter(Annotation.timestamp >= start_date, Annotation.timestamp <= end_date)
         .group_by(
             Annotation.user_id,
             User.nickname,
@@ -176,6 +179,7 @@ def get_leaderboard_counts():
     evaluation_counts = (
         select(Evaluation.user_id, User.nickname, func.count(Evaluation.id))
         .join(User)
+        .filter(Evaluation.timestamp >= start_date, Evaluation.timestamp <= end_date)
         .group_by(
             Evaluation.user_id,
             User.nickname,

--- a/annotation_tool/pages/leaderboard.py
+++ b/annotation_tool/pages/leaderboard.py
@@ -1,6 +1,9 @@
+from datetime import date, timedelta
+
 import pandas as pd
 import streamlit as st
 
+from annotation_tool.backend.config import get_competition_date
 from annotation_tool.backend.models import get_leaderboard_counts
 
 ANNOTATION_SCORE_FACTOR = 5
@@ -10,9 +13,13 @@ EVALUATION_SCORE_FACTOR = 1
 def show():
     st.header("📊 Leaderboard")
 
+    competition_start_date = get_competition_date("competition_start_date") or date(2022, 11, 23)
+    competition_end_date = get_competition_date("competition_end_date") or date(2023, 1, 31)
+    prize_claim_date = competition_end_date + timedelta(weeks=4)
+
     st.dataframe(get_leaderboard_dataframe(), use_container_width=True)
 
-    prize_info = """
+    prize_info = f"""
     ### Competition 🏆
 
     If you contribute to Song Describer, you'll also have a chance to win one of our prizes!
@@ -26,7 +33,7 @@ def show():
     * 🥈 2nd place: £60
     * 🥉 3rd place: £40 
 
-    The competition opens on 23/11/2022 and ends on 31/01/2023 AOE.
+    The competition opens on {competition_start_date:%d/%m/%Y} and ends on {competition_end_date:%d/%m/%Y} AOE.
 
     #### How do I enter the competition?
     All users contributing to Song Describer while the competition is running will automatically be considered
@@ -48,7 +55,7 @@ def show():
     #### How do I claim my prize?
     If you're one of the top 3 ranked contributors on our leaderboard when the competition ends, you 
     can claim your prize by emailing your unique user ID to [i.manco@qmul.ac.uk](mailto:i.manco@qmul.ac.uk) 
-    by 31/02/2023. Please note, if you cannot provide your user ID, we will not be able to verify your
+    by {prize_claim_date:%d/%m/%Y}. Please note, if you cannot provide your user ID, we will not be able to verify your
     contributions and you won't be able to claim your prize.
 
     We will check that your contributions adhere to the annotation guidelines outlined on this platform

--- a/annotation_tool/pages/leaderboard.py
+++ b/annotation_tool/pages/leaderboard.py
@@ -33,7 +33,7 @@ def show():
     * 🥈 2nd place: £60
     * 🥉 3rd place: £40 
 
-    The competition opens on {competition_start_date:%d/%m/%Y} and ends on {competition_end_date:%d/%m/%Y} AOE.
+    The competition opens on {competition_start_date:%d/%m/%Y} and ends on {competition_end_date:%d/%m/%Y} GMT.
 
     #### How do I enter the competition?
     All users contributing to Song Describer while the competition is running will automatically be considered

--- a/annotation_tool/pages/leaderboard.py
+++ b/annotation_tool/pages/leaderboard.py
@@ -9,13 +9,13 @@ from annotation_tool.backend.models import get_leaderboard_counts
 ANNOTATION_SCORE_FACTOR = 5
 EVALUATION_SCORE_FACTOR = 1
 
+competition_start_date = get_competition_date("competition_start_date") or date(2022, 11, 23)
+competition_end_date = get_competition_date("competition_end_date") or date(2023, 1, 31)
+prize_claim_date = competition_end_date + timedelta(weeks=4)
+
 
 def show():
     st.header("📊 Leaderboard")
-
-    competition_start_date = get_competition_date("competition_start_date") or date(2022, 11, 23)
-    competition_end_date = get_competition_date("competition_end_date") or date(2023, 1, 31)
-    prize_claim_date = competition_end_date + timedelta(weeks=4)
 
     st.dataframe(get_leaderboard_dataframe(), use_container_width=True)
 
@@ -67,7 +67,7 @@ def show():
 
 
 def get_leaderboard_dataframe():
-    data = get_leaderboard_counts()
+    data = get_leaderboard_counts(competition_start_date, competition_end_date)
     captions_written_column = "Annotations"
     captions_evaluated_column = "Evaluations"
     name_column = "Nickname"

--- a/annotation_tool/pages/welcome.py
+++ b/annotation_tool/pages/welcome.py
@@ -9,7 +9,7 @@ from annotation_tool.pages.flow_control import (
     set_user_id,
     RETURNING_USER_KEY,
 )
-from annotation_tool.pages.leaderboard import get_leaderboard_dataframe
+from annotation_tool.pages.leaderboard import get_leaderboard_dataframe, competition_end_date
 
 INPUT_USER_ID_KEY = "input_user_id"
 
@@ -41,10 +41,10 @@ def draw_main_page(callback):
 
     """
 
-    competition = """
+    competition = f"""
     ###### 🏆 Competition 🏆
 
-    Up until **31st January 2023**, if you contribute to Song Describer, you'll have a 
+    Up until **{competition_end_date:%d %B %Y}**, if you contribute to Song Describer, you'll have a 
     chance to win one of our prizes. As a way to say thank you for your time and effort, 
     we are offering [Abbey Road Studios](https://shop.abbeyroad.com/) gift vouchers to 
     the 3 participants with the highest overall score. More details on the Leaderboard page.


### PR DESCRIPTION
To run more competition rounds we need to filter the leaderboard according to competition start and end dates.

The competition dates can be specified in the config like so:
```toml
[competition]
competition_start_date = "2023/03/08"
competition_end_date = "2050/11/28"

```