### PR TITLE
prepare to put Song Describer to sleep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/annotation_tool/backend/scripts/data_dump*/
+annotation_tool/backend/scripts/.streamlit/secrets.toml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/annotation_tool/README.md
+++ b/annotation_tool/README.md
@@ -25,3 +25,10 @@ Similar to pip, pip-tools must be installed in each of your project's virtual en
 Now, run pip-compile requirements.in
 
 ```$ pip-compile requirements.in```
+
+## Database
+
+The tool was developed for a PostgreSQL database.
+The database connection is configured in the streamlit secrets.toml file.
+
+For limited testing purposes, an SQLite database is also available. Not all features might work as expected.

--- a/annotation_tool/backend/scripts/download_data.py
+++ b/annotation_tool/backend/scripts/download_data.py
@@ -24,6 +24,9 @@ def fetch_tables(data_models: list[Type[SQLModel]], out_base_path: Path):
         df.to_pickle(
             out_base_path / f"{data_model.__tablename__}.pickle",
         )
+        df.to_csv(
+            out_base_path / f"{data_model.__tablename__}.csv",
+        )
 
 
 if __name__ == "__main__":

--- a/annotation_tool/components/custom_audio.py
+++ b/annotation_tool/components/custom_audio.py
@@ -37,8 +37,12 @@ def get_trimmed_audio_element(audio_url: str, max_duration: int = 120):
         }} catch (e) {{
           // console.error(e.message);
           const para = document.createElement('p');
-          para.textContent = 'Your browser is not supported!';
+          para.textContent = 'Cannot play audio. Your browser is not supported!';
+          const errmsg = document.createElement('p');
+          errmsg.textContent = e.message;
           document.body.appendChild(para);
+          document.body.appendChild(errmsg);
+          audio.remove();
         }}
       }}
 

--- a/annotation_tool/pages/welcome.py
+++ b/annotation_tool/pages/welcome.py
@@ -25,6 +25,15 @@ def draw_main_page(callback):
         """
     )
 
+    warning_text = """
+        Song Describer is currently hibernating (as of November 2023) :sleeping:.
+        We are not collecting any new data, but you can still browse the website.
+        
+        Check out the [the dataset page](https://zenodo.org/search?q=Song%20Describer%20Dataset) if you're interested in
+        the data we've collected so far.
+        """
+    st.warning(warning_text, icon="⚠️")
+
     intro = """
     ###
 
@@ -81,6 +90,8 @@ def draw_main_page(callback):
         st.write(FAQS_TEXT)
 
     st.write(informed_consent)
+
+    st.warning(warning_text, icon="⚠️")
 
     _, col3, _ = st.columns([2, 1, 2])
     col3.button(


### PR DESCRIPTION
This PR adds a dummy database so that we can put the website in hibernation while retaining most of the functionality.
